### PR TITLE
Use updated values for AirGradient API

### DIFF
--- a/air-gradient-pro-diy.yaml
+++ b/air-gradient-pro-diy.yaml
@@ -191,7 +191,8 @@ interval:
             rco2: !lambda return to_string(id(co2).state);
             atmp: !lambda return to_string(id(temp).state);
             rhum: !lambda return to_string(id(humidity).state);
-            tvoc: !lambda return to_string(id(voc).state);
+            tvoc_index: !lambda return to_string(id(voc).state);
+            nox_index: !lambda return to_string(id(nox).state);
           verify_ssl: false
 
 uart:


### PR DESCRIPTION
Use the updated value `voc_index` when sending data to the AirGradient API server. Additionally, also send NOX values using `nox_index`.
Reference: https://github.com/airgradienthq/arduino/blob/356e76f10ec002c2f6d91f361cc2b1c683c9c3e1/examples/DIY_PRO_V4_2/DIY_PRO_V4_2.ino#L381-L382 